### PR TITLE
Remove usage of UIWebView

### DIFF
--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -180,8 +180,10 @@ RCT_EXPORT_MODULE(RNDeviceInfo)
 #if TARGET_OS_TV
     return @"not available";
 #else
-    UIWebView* webView = [[UIWebView alloc] initWithFrame:CGRectZero];
-    return [webView stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];
+	// `userAgent` is not used in the Khan Academy app.
+	// For now we'll crash if this is called. In the future we should upgrade
+	// to the non-vendored version of this lib which uses WKWebView.
+	fatalError(@"`userAgent` property is not supported!");
 #endif
 }
 


### PR DESCRIPTION
## Summary:

Issue: [MOB-3302](https://khanacademy.atlassian.net/browse/MOB-3302)

Apple has fully deprecated UIWebView and will begin rejecting apps that use it as of December 2020. We don't use the `userAgent` prop so I'm just making it blow up for now so we can remove the usage of `UIWebView`

## Test plan: