### PR TITLE
Fix crash in `userAgent`

### DIFF
--- a/ios/RNDeviceInfo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ios/RNDeviceInfo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ios/RNDeviceInfo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ios/RNDeviceInfo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>IDEDidComputeMac32BitWarning</key>
-	<true/>
-</dict>
-</plist>

--- a/ios/RNDeviceInfo/RNDeviceInfo.m
+++ b/ios/RNDeviceInfo/RNDeviceInfo.m
@@ -183,7 +183,8 @@ RCT_EXPORT_MODULE(RNDeviceInfo)
 	// `userAgent` is not used in the Khan Academy app.
 	// For now we'll crash if this is called. In the future we should upgrade
 	// to the non-vendored version of this lib which uses WKWebView.
-	fatalError(@"`userAgent` property is not supported!");
+	NSAssert(NO, @"`userAgent` property is not supported!");
+	return @"not available";
 #endif
 }
 


### PR DESCRIPTION
## Summary:

Issue: MOB-3302

I messed up when I forced a crash in the `userAgent` property. `fatalError` is a Swift-ism. Switching to an `NSAssert()` that will always fail.

## Test plan:

Ref this commit in the app and compile!